### PR TITLE
Added string representation of int for JavaScript

### DIFF
--- a/astexport/export.py
+++ b/astexport/export.py
@@ -2,10 +2,6 @@ import ast
 import json
 
 
-JAVASCRIPT_MAX_SAFE_INT = 2 ** 53 - 1
-JAVASCRIPT_MIN_SAFE_INT = -(2 ** 53 - 1)
-
-
 def export_json(tree, pretty_print=False):
     assert(isinstance(tree, ast.AST))
     return json.dumps(
@@ -78,15 +74,13 @@ class DictExportVisitor:
 
     def visit_field_Num_n(self, val):
         if isinstance(val, int):
-            data = {self.ast_type_field: "int", "n": val}
-
-            # JavaScript integers are limited to 2**53 - 1 bits,
-            # so we add a string representation of the integer
-            # if it's outside of the safe range
-            if val > JAVASCRIPT_MAX_SAFE_INT or val < JAVASCRIPT_MIN_SAFE_INT:
-                data["n_str"] = str(val)
-
-            return data
+            return {
+                self.ast_type_field: "int",
+                "n": val,
+                # JavaScript integers are limited to 2**53 - 1 bits,
+                # so we add a string representation of the integer
+                "n_str": str(val),
+            }
         elif isinstance(val, float):
             return {
                 self.ast_type_field: "float",

--- a/astexport/export.py
+++ b/astexport/export.py
@@ -2,6 +2,10 @@ import ast
 import json
 
 
+JAVASCRIPT_MAX_SAFE_INT = 2 ** 53 - 1
+JAVASCRIPT_MIN_SAFE_INT = -(2 ** 53 - 1)
+
+
 def export_json(tree, pretty_print=False):
     assert(isinstance(tree, ast.AST))
     return json.dumps(
@@ -74,10 +78,15 @@ class DictExportVisitor:
 
     def visit_field_Num_n(self, val):
         if isinstance(val, int):
-            return {
-                self.ast_type_field: "int",
-                "n": val
-            }
+            data = {self.ast_type_field: "int", "n": val}
+
+            # JavaScript integers are limited to 2**53 - 1 bits,
+            # so we add a string representation of the integer
+            # if it's outside of the safe range
+            if val > JAVASCRIPT_MAX_SAFE_INT or val < JAVASCRIPT_MIN_SAFE_INT:
+                data["n_str"] = str(val)
+
+            return data
         elif isinstance(val, float):
             return {
                 self.ast_type_field: "float",

--- a/tests/export_test.py
+++ b/tests/export_test.py
@@ -220,5 +220,72 @@ class TestExportJson(unittest.TestCase):
                 "name": "function",
                 "returns": None
             }
-        )
+        ),
+        TestIO(
+            input=ast.Module(
+                body=[
+                    ast.Assign(
+                        targets=[ast.Name(ctx=ast.Store(), id="x")],
+                        value=ast.Num(n=18446744073709551616),
+                    ),
+                    ast.Assign(
+                        targets=[ast.Name(ctx=ast.Store(), id="x")],
+                        value=ast.Num(n=-18446744073709551616),
+                    )
+                ]
+            ),
+            output={
+                "ast_type": "Module",
+                "body": [
+                    {
+                        "ast_type": "Assign",
+                        "targets": [
+                            {
+                                "ast_type": "Name",
+                                "id": "x",
+                                "ctx": {"ast_type": "Store"},
+                                "lineno": None,
+                                "col_offset": None,
+                            }
+                        ],
+                        "value": {
+                            "ast_type": "Num",
+                            "n": {
+                                "ast_type": "int",
+                                "n": 18446744073709551616,
+                                "n_str": "18446744073709551616",
+                            },
+                            "lineno": None,
+                            "col_offset": None,
+                        },
+                        "lineno": None,
+                        "col_offset": None,
+                    },
+                    {
+                        "ast_type": "Assign",
+                        "targets": [
+                            {
+                                "ast_type": "Name",
+                                "id": "x",
+                                "ctx": {"ast_type": "Store"},
+                                "lineno": None,
+                                "col_offset": None,
+                            }
+                        ],
+                        "value": {
+                            "ast_type": "Num",
+                            "n": {
+                                "ast_type": "int",
+                                "n": -18446744073709551616,
+                                "n_str": "-18446744073709551616",
+                            },
+                            "lineno": None,
+                            "col_offset": None,
+                        },
+                        "lineno": None,
+                        "col_offset": None,
+                    }
+                ],
+            },
+        ),
     ]

--- a/tests/export_test.py
+++ b/tests/export_test.py
@@ -56,7 +56,8 @@ class TestExportJson(unittest.TestCase):
                             "lineno": None,
                             "n": {
                                 "ast_type": "int",
-                                "n": 5
+                                "n": 5,
+                                "n_str": "5"
                             }
                         }
                     }
@@ -220,72 +221,5 @@ class TestExportJson(unittest.TestCase):
                 "name": "function",
                 "returns": None
             }
-        ),
-        TestIO(
-            input=ast.Module(
-                body=[
-                    ast.Assign(
-                        targets=[ast.Name(ctx=ast.Store(), id="x")],
-                        value=ast.Num(n=18446744073709551616),
-                    ),
-                    ast.Assign(
-                        targets=[ast.Name(ctx=ast.Store(), id="x")],
-                        value=ast.Num(n=-18446744073709551616),
-                    )
-                ]
-            ),
-            output={
-                "ast_type": "Module",
-                "body": [
-                    {
-                        "ast_type": "Assign",
-                        "targets": [
-                            {
-                                "ast_type": "Name",
-                                "id": "x",
-                                "ctx": {"ast_type": "Store"},
-                                "lineno": None,
-                                "col_offset": None,
-                            }
-                        ],
-                        "value": {
-                            "ast_type": "Num",
-                            "n": {
-                                "ast_type": "int",
-                                "n": 18446744073709551616,
-                                "n_str": "18446744073709551616",
-                            },
-                            "lineno": None,
-                            "col_offset": None,
-                        },
-                        "lineno": None,
-                        "col_offset": None,
-                    },
-                    {
-                        "ast_type": "Assign",
-                        "targets": [
-                            {
-                                "ast_type": "Name",
-                                "id": "x",
-                                "ctx": {"ast_type": "Store"},
-                                "lineno": None,
-                                "col_offset": None,
-                            }
-                        ],
-                        "value": {
-                            "ast_type": "Num",
-                            "n": {
-                                "ast_type": "int",
-                                "n": -18446744073709551616,
-                                "n_str": "-18446744073709551616",
-                            },
-                            "lineno": None,
-                            "col_offset": None,
-                        },
-                        "lineno": None,
-                        "col_offset": None,
-                    }
-                ],
-            },
         ),
     ]


### PR DESCRIPTION
ON JavaScript integers a restricted to +/- `2**53-1` thus it'll be impossible to parse `Num` dumps with `n` outside that rage.

Added an extra key to the `Num`s dict with the string representation of the integer in case it's not compatible with JavaScript limitation.