### PR TITLE
Decode strings as utf-8

### DIFF
--- a/astexport/export.py
+++ b/astexport/export.py
@@ -65,6 +65,8 @@ class DictExportVisitor:
             return self.visit(val)
         if isinstance(val, (list, tuple)):
             return [self.visit(x) for x in val]
+        elif isinstance(val, bytes):
+            return val.decode('utf-8')
         return val
 
     # Special visitors


### PR DESCRIPTION
Fix bytes cannot be json serialized error:

```py
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type bytes is not JSON serializable
```
Can be observed exporting `cpython/Lib/_bootsubprocess.py`